### PR TITLE
[refactor] - 술 전체 조회 시 술 데이터만 출력

### DIFF
--- a/src/main/java/com/alevel/backend/controller/AlcoholController.java
+++ b/src/main/java/com/alevel/backend/controller/AlcoholController.java
@@ -1,10 +1,12 @@
 package com.alevel.backend.controller;
 
+import com.alevel.backend.controller.dto.AlcoholResponseDto;
 import com.alevel.backend.domain.response.ResponseMessage;
 import com.alevel.backend.domain.response.ResultResponse;
 import com.alevel.backend.domain.response.StatusCode;
 import com.alevel.backend.service.AlcoholService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
@@ -32,12 +34,13 @@ public class AlcoholController {
             String type, String category,
             @PageableDefault(size = 6, sort = "hit", direction = Sort.Direction.DESC) Pageable pageable) {
         try {
-            return ResultResponse.success(alcoholService.findAllAlcohol(type, category, pageable));
+            Page<AlcoholResponseDto> alcohol = alcoholService.findAllAlcohol(type, category, pageable);
+            System.out.println("alcohol:" + alcohol);
+            return ResultResponse.success(alcohol.getContent());
         } catch (Exception e) {
             return ResultResponse.fail(StatusCode.BAD_REQUEST, ResponseMessage.FAIL);
         }
     }
-
 
     /**
      *

--- a/src/main/java/com/alevel/backend/controller/dto/AlcoholResponseDto.java
+++ b/src/main/java/com/alevel/backend/controller/dto/AlcoholResponseDto.java
@@ -1,0 +1,20 @@
+package com.alevel.backend.controller.dto;
+
+import lombok.Getter;
+
+@Getter
+public class AlcoholResponseDto {
+    private final String name;
+    private final String volume;
+    private final String size;
+    private final Integer price;
+    private final String image;
+
+    public AlcoholResponseDto(String name, String volume, String size, Integer price, String image) {
+        this.name = name;
+        this.volume = volume;
+        this.size = size;
+        this.price = price;
+        this.image = image;
+    }
+}

--- a/src/main/java/com/alevel/backend/domain/alcohol/AlcoholRepositoryCustom.java
+++ b/src/main/java/com/alevel/backend/domain/alcohol/AlcoholRepositoryCustom.java
@@ -1,10 +1,11 @@
 package com.alevel.backend.domain.alcohol;
 
+import com.alevel.backend.controller.dto.AlcoholResponseDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface AlcoholRepositoryCustom {
 
-    Page<Alcohol> findAllAlcohol(String type, String category, Pageable pageable);
+    Page<AlcoholResponseDto> findAllAlcohol(String type, String category, Pageable pageable);
 
 }

--- a/src/main/java/com/alevel/backend/domain/alcohol/AlcoholRepositoryCustomImpl.java
+++ b/src/main/java/com/alevel/backend/domain/alcohol/AlcoholRepositoryCustomImpl.java
@@ -1,7 +1,9 @@
 package com.alevel.backend.domain.alcohol;
 
+import com.alevel.backend.controller.dto.AlcoholResponseDto;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.PathBuilder;
 import com.querydsl.jpa.impl.JPAQuery;
@@ -26,10 +28,12 @@ public class AlcoholRepositoryCustomImpl implements AlcoholRepositoryCustom {
     QAlcohol alcohol = QAlcohol.alcohol;
 
     @Override
-    public Page<Alcohol> findAllAlcohol(String type, String category, Pageable pageable) {
+    public Page<AlcoholResponseDto> findAllAlcohol(String type, String category, Pageable pageable) {
 
-        JPAQuery<Alcohol> query = queryFactory
-                .selectFrom(alcohol)
+        JPAQuery<AlcoholResponseDto> query = queryFactory
+                .select(Projections.constructor(AlcoholResponseDto.class,
+                        alcohol.name, alcohol.volume, alcohol.size, alcohol.price, alcohol.image))
+                .from(alcohol)
                 .where(eqType(type),
                         eqCategory(category))
                 .offset(pageable.getOffset()) // 페이지 번호
@@ -41,7 +45,7 @@ public class AlcoholRepositoryCustomImpl implements AlcoholRepositoryCustom {
                     pathBuilder.get(o.getProperty())));
         }
 
-        List<Alcohol> content = query.fetch();
+        List<AlcoholResponseDto> content = query.fetch();
 
         long totalCount = queryFactory.select(alcohol.count())
                 .from(alcohol)

--- a/src/main/java/com/alevel/backend/service/AlcoholService.java
+++ b/src/main/java/com/alevel/backend/service/AlcoholService.java
@@ -1,5 +1,6 @@
 package com.alevel.backend.service;
 
+import com.alevel.backend.controller.dto.AlcoholResponseDto;
 import com.alevel.backend.domain.alcohol.Alcohol;
 import com.alevel.backend.domain.alcohol.AlcoholRepository;
 import com.alevel.backend.domain.scrapalcohol.ScrapAlcohol;
@@ -28,7 +29,7 @@ public class AlcoholService {
 
     private JPAQueryFactory queryFactory;
 
-    public Page<Alcohol> findAllAlcohol(String type, String category, Pageable pageable) {
+    public Page<AlcoholResponseDto> findAllAlcohol(String type, String category, Pageable pageable) {
         return alcoholRepository.findAllAlcohol(type, category, pageable);
     }
 


### PR DESCRIPTION
## 변경사항
1. 기존 **페이징 로직은 유지**하나 페이징 데이터 제외하고 **술 데이터만 리턴** 되도록 수정했습니다.
2. 술 데이터도 모든 정보가 필요하지 않아보여 **술 이름, 도수, 용량, 가격, 이미지** 값만 사용하도록 했습니다.
<img width="130" alt="스크린샷 2022-09-25 오후 3 49 45" src="https://user-images.githubusercontent.com/44694206/192131828-3c8e388b-4af2-452f-8b2d-a081e53de283.png">

## 테스트
- 페이징 파라미터
```
- page : 요청 페이지 번호 (0부터 시작)
- size : 한 페이지당 조회할 데이터 개수 (default : 20)
- sort : 정렬 컬럼명, 정렬 기준 (default : asc)
```

- 샘플 URL 1
```
localhost:8080/alcohols?type=와인&category=&size=2&page=1&sort=volume,asc
```

- 결과 1
```
{
    "status": 200,
    "message": "성공",
    "data": [
        {
            "name": "뵈브 클리코 옐로우 라벨 브뤼 샴페인",
            "volume": "12",
            "size": "750",
            "price": 68000,
            "image": null
        },
        {
            "name": "구스타브 로렌츠 피노 누아 리저브",
            "volume": "12.5",
            "size": "750",
            "price": 64000,
            "image": null
        }
    ]
}
```

- 샘플 URL 2
```
localhost:8080/alcohols?type=와인&category=&size=2&page=2&sort=volume,asc
```

- 결과 2
```
{
    "status": 200,
    "message": "성공",
    "data": [
        {
            "name": "돔 페리뇽 P2",
            "volume": "12~13",
            "size": "750",
            "price": 650000,
            "image": null
        },
        {
            "name": "머드 하우스, 말보로 소비뇽 블랑",
            "volume": "13",
            "size": "750",
            "price": 55000,
            "image": null
        }
    ]
}
```