### PR TITLE
[feat] - 한줄리뷰 삭제, 한줄리뷰/게시글상세조회 수정

### DIFF
--- a/src/main/java/com/alevel/backend/controller/ReviewController.java
+++ b/src/main/java/com/alevel/backend/controller/ReviewController.java
@@ -1,5 +1,7 @@
 package com.alevel.backend.controller;
 
+import com.alevel.backend.domain.response.ResponseMessage;
+import com.alevel.backend.domain.response.StatusCode;
 import com.alevel.backend.dto.AlcoholReviewRequestDto;
 import com.alevel.backend.dto.AlcoholReviewSaveDto;
 import com.alevel.backend.domain.response.ResultResponse;
@@ -11,7 +13,7 @@ import org.springframework.web.bind.annotation.*;
 public class ReviewController {
 
     @Autowired
-    private ReviewService reviewService;
+    private final ReviewService reviewService;
 
     @Autowired
     public ReviewController(ReviewService reviewService) {
@@ -29,11 +31,24 @@ public class ReviewController {
     }
 
     /**
-     * 한 줄 리뷰 조회
+     * 한 줄 리뷰 조회 (전체)
      * 사용: AlcoholController.getAlcoholDetailPage
      */
     @GetMapping(value = "/alcohols/{id}/review")
-    public ResultResponse getReview(@PathVariable("id") Long id){
+    public ResultResponse getReviews(@PathVariable("id") Long id){
         return ResultResponse.success(reviewService.getReview(id));
+    }
+
+    /**
+     * 한 줄 리뷰 삭제
+     */
+    @DeleteMapping(value = "/alcohols/{id}/review/{review-id}")
+    public ResultResponse deleteReview(@PathVariable("id") Long id, @PathVariable("review-id") Long reviewId){
+        try {
+            reviewService.deleteReviewById(reviewId);
+            return ResultResponse.success();
+        } catch (Exception e) {
+            return ResultResponse.fail(StatusCode.NOT_FOUND, ResponseMessage.INVALIDATED_REVIEW);
+        }
     }
 }

--- a/src/main/java/com/alevel/backend/domain/review/ReviewRepository.java
+++ b/src/main/java/com/alevel/backend/domain/review/ReviewRepository.java
@@ -1,15 +1,9 @@
 package com.alevel.backend.domain.review;
 
-import com.alevel.backend.domain.alcohol.Alcohol;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-
-
 @Repository
-public interface ReviewRepository extends JpaRepository<Review, Long> {
-
-    List<Review> findAllByAlcohol(Alcohol alcohol);
+public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewRepositoryCustom {
 
 }

--- a/src/main/java/com/alevel/backend/domain/review/ReviewRepositoryCustom.java
+++ b/src/main/java/com/alevel/backend/domain/review/ReviewRepositoryCustom.java
@@ -1,0 +1,12 @@
+package com.alevel.backend.domain.review;
+
+
+import com.alevel.backend.dto.AlcoholReviewResponseDto;
+
+import java.util.List;
+
+public interface ReviewRepositoryCustom {
+
+    List<AlcoholReviewResponseDto> findAllByAlcoholId(Long id);
+
+}

--- a/src/main/java/com/alevel/backend/domain/review/ReviewRepositoryCustomImpl.java
+++ b/src/main/java/com/alevel/backend/domain/review/ReviewRepositoryCustomImpl.java
@@ -1,0 +1,37 @@
+package com.alevel.backend.domain.review;
+
+import com.alevel.backend.dto.AlcoholReviewResponseDto;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import javax.persistence.EntityManager;
+import java.util.List;
+
+public class ReviewRepositoryCustomImpl implements ReviewRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    public ReviewRepositoryCustomImpl(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    QReview review = QReview.review1;
+
+    @Override
+    public List<AlcoholReviewResponseDto> findAllByAlcoholId(Long id) {
+        return queryFactory
+                .select(
+                        Projections.constructor(
+                                AlcoholReviewResponseDto.class,
+                                review.id,
+                                review.alcohol.id,
+                                review.user.username,
+                                review.review,
+                                review.createdDate
+                        )
+                )
+                .from(review)
+                .where(review.alcohol.id.eq(id))
+                .fetch();
+    }
+
+}

--- a/src/main/java/com/alevel/backend/dto/AlcoholReviewResponseDto.java
+++ b/src/main/java/com/alevel/backend/dto/AlcoholReviewResponseDto.java
@@ -9,13 +9,15 @@ import java.time.LocalDateTime;
 @Setter
 public class AlcoholReviewResponseDto {
 
-    private Long alcoholid;
+    private Long id;
+    private Long alcoholId;
     private String username;
     private String content;
     private LocalDateTime date;
 
-    public AlcoholReviewResponseDto(Long alcoholid, String username, String content, LocalDateTime date) {
-        this.alcoholid = alcoholid;
+    public AlcoholReviewResponseDto(Long id, Long alcoholId, String username, String content, LocalDateTime date) {
+        this.id = id;
+        this.alcoholId = alcoholId;
         this.username = username;
         this.content = content;
         this.date = date;

--- a/src/main/java/com/alevel/backend/dto/PostDetailResponseDto.java
+++ b/src/main/java/com/alevel/backend/dto/PostDetailResponseDto.java
@@ -19,6 +19,7 @@ public class PostDetailResponseDto {
     private final Integer scrapCount;
     private final Integer likeCount;
     private final String alcoholName;
+    private final String alcoholType;
     private final String flavor;
     private final BigDecimal volume;
     private final String price;
@@ -39,6 +40,7 @@ public class PostDetailResponseDto {
         this.modifiedDate = post.getModifiedDate();
 
         this.alcoholName = post.getAlcoholName();
+        this.alcoholType = post.getAlcoholType();
         this.flavor = post.getFlavor();
         this.volume = post.getVolume();
         this.price = post.getPrice();

--- a/src/main/java/com/alevel/backend/service/ReviewService.java
+++ b/src/main/java/com/alevel/backend/service/ReviewService.java
@@ -42,7 +42,8 @@ public class ReviewService {
     }
 
     public List<AlcoholReviewResponseDto> getReview(Long id){
-        return reviewRepository.findAllByAlcoholId(id);
+        List<AlcoholReviewResponseDto> review = reviewRepository.findAllByAlcoholId(id);
+        return review.isEmpty() ? null : review;
     }
 
     public void deleteReviewById(Long id){

--- a/src/main/java/com/alevel/backend/service/ReviewService.java
+++ b/src/main/java/com/alevel/backend/service/ReviewService.java
@@ -9,11 +9,10 @@ import com.alevel.backend.domain.review.ReviewRepository;
 import com.alevel.backend.domain.user.User;
 import com.alevel.backend.domain.user.UserRepository;
 import com.alevel.backend.exception.ExceededNumberException;
+import com.alevel.backend.exception.InvalidateReviewException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -43,24 +42,14 @@ public class ReviewService {
     }
 
     public List<AlcoholReviewResponseDto> getReview(Long id){
-        Alcohol alcohol = alcoholRepository.getReferenceById(id);
-        List<Review> review = reviewRepository.findAllByAlcohol(alcohol);
+        return reviewRepository.findAllByAlcoholId(id);
+    }
 
-        if (review.isEmpty()) {
-            //throw new InvalidateReviewException();
-            return null;
-        }
-
-        List<AlcoholReviewResponseDto> dto = new ArrayList();;
-
-        for (int i=0; i<review.size(); i++) {
-            String user = review.get(i).getUser().getUsername();
-            String content = review.get(i).getReview();
-            LocalDateTime date = review.get(i).getModifiedDate();
-
-            dto.add(new AlcoholReviewResponseDto(id, user, content, date));
-        }
-
-        return dto;
+    public void deleteReviewById(Long id){
+        reviewRepository.delete(
+                reviewRepository.findById(id).orElseThrow(
+                        InvalidateReviewException::new
+                )
+        );
     }
 }


### PR DESCRIPTION
## 추가 및 변경사항
- 한줄리뷰 삭제 API
이 API 개발하면서 URI 와 DB 구조에 대해 고민해볼 수 있었습니다.
리뷰테이블 pk를 `게시글번호+리뷰번호`로 잡았으면 그나마 지금보다 더 URI 에 맞는 모양이 되지 않았을까 싶네요..

- 한줄리뷰 조회 API
리뷰 삭제할 때 리뷰번호가 필요해서 리뷰 조회에 리뷰번호도 반환되도록 추가했습니다.

- 게시글상세조회 API
술 타입 데이터도 반환되도록 수정했습니다.